### PR TITLE
Feat/internal ipfs node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
 .PHONY: test
 
-build: 
-	npm install
-
-test:
+up:
 	BIGSECTORS=true docker-compose up -d
+
+deps:
 	npm install
+
+down:
+	BIGSECTORS=true docker-compose down
+
+test: up deps
 	npm test
+	make down
 
-clean:
+clean: down
 	rm -rf orbitdb
 	rm -rf node_modules
 	rm -f package-lock.json
 
-rebuild:
-	rm -rf orbitdb
-	rm -rf node_modules
-	rm -f package-lock.json
-	npm install
+rebuild: clean down test

--- a/src/index.js
+++ b/src/index.js
@@ -28,18 +28,22 @@ class PowergateIO {
 
   // TODO: Config
   // TODO: Call this createDefault?
-  static async create(host="http://0.0.0.0:6002",
-    ipfsOptions = { host:"0.0.0.0", port:"5001"}) {
-
+  static async create(host="http://0.0.0.0:6002") {
     const pow = createPow({ host })
+    const ffs = await pow.ffs.create()
+    pow.setToken(ffs.token)
+
     // TODO: Get IPFS info from powergate?
-    const ipfs = new IpfsClient(ipfsOptions)
+    const ipfsOptions = parseURL(host)
+    const ipfs = new IpfsClient(ipfsOptions, {
+      headers: {
+        'x-ipfs-ffs-auth': ffs.token
+      }
+    })
     const orbitdb = await OrbitDB.createInstance(ipfs)
 
     const jobsDb = await orbitdb.docs('jobs', { indexBy: 'id' })
 
-    const ffs = await pow.ffs.create()
-    pow.setToken(ffs.token)
 
     // Create default address
     const { addr } = await pow.ffs.newAddr("_default")

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 const OrbitDB = require('orbit-db')
 const { createPow } = require('@textile/powergate-client')
 const IpfsClient = require('ipfs-http-client')
-const { waitForBalance } = require('./utils')
+const {
+  parseURL,
+  waitForBalance,
+} = require('./utils')
 const Log = require('ipfs-log')
 
 // Workaround wrapper function

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const url = require('url')
+
 function waitForBalance(ffs, address, greaterThan) {
   return new Promise(async (resolve, reject) => {
     while (true) {
@@ -24,6 +26,17 @@ function waitForBalance(ffs, address, greaterThan) {
   })
 }
 
+const parseURL = (host) => {
+  const urlObj = url.parse(host)
+  const ipfsOptions = {
+    host: urlObj.hostname,
+    port: 5001, // urlObj.port,
+    protocol: urlObj.protocol.replace(':', '')
+  }
+  return ipfsOptions
+}
+
 module.exports = {
+  parseURL,
   waitForBalance
 }


### PR DESCRIPTION
This PR utilizes the `x-ipfs-ffs-auth` header to access the IPFS node that is attached to `pow`. This should help with connecting to the hosted testnet nodes :+1: 